### PR TITLE
Revert "fix pkgdown build fail by using binary"

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -37,7 +37,7 @@ jobs:
       - name: Install dependencies
         run: |
           install.packages("remotes")
-          remotes::install_deps(dependencies = TRUE, type = "binary")
+          remotes::install_deps(dependencies = TRUE)
           remotes::install_dev("pkgdown")
         shell: Rscript {0}
 


### PR DESCRIPTION
Reverts Sage-Bionetworks/sageseqr#76

Using binaries introduced other new failures.