### PR TITLE
model_variables is an optional argument

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -50,7 +50,7 @@ Imports:
     tidyr,
     tibble,
     utils,
-    variancePartition (== 1.19.17),
+    variancePartition (== 1.19.16),
     quantreg
 Additional_repositories:
     http://ran.synapse.org

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -50,7 +50,7 @@ Imports:
     tidyr,
     tibble,
     utils,
-    variancePartition (>= 1.19.11),
+    variancePartition (== 1.19.17),
     quantreg
 Additional_repositories:
     http://ran.synapse.org

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -50,13 +50,13 @@ Imports:
     tidyr,
     tibble,
     utils,
-    variancePartition (== 1.19.16),
+    variancePartition,
     quantreg
 Additional_repositories:
     http://ran.synapse.org
 Remotes:
     th1vairam/CovariateAnalysis@dev,
     Sage-Bionetworks/sagethemes@main,
-    GabrielHoffman/variancePartition
+    GabrielHoffman/variancePartition@da5003f
 VignetteBuilder:
     knitr

--- a/R/functions.R
+++ b/R/functions.R
@@ -506,10 +506,11 @@ build_formula <- function(md, primary_variable, model_variables = names(md)) {
 #' @inheritParams cqn
 #' @inheritParams coerce_factors
 #' @inheritParams build_formula
+#' @inheritDotParams build_formula
 #' @inheritParams cqn
 #' @export
 differential_expression <- function(filtered_counts, cqn_counts, md, primary_variable,
-                                    biomart_results, model_variables = NULL) {
+                                    biomart_results, ...) {
   metadata_input <- build_formula(md, model_variables, primary_variable)
   gene_expression <- edgeR::DGEList(filtered_counts)
   gene_expression <- edgeR::calcNormFactors(gene_expression)
@@ -587,11 +588,13 @@ differential_expression <- function(filtered_counts, cqn_counts, md, primary_var
 #' @param conditions A list of conditions to test as `primary_variable`
 #' in \code{"sagseqr::differential_expression()"}.
 #' @inheritParams differential_expression
+#' @inheritParams build_formula
 #' @export
-wrap_de <- function(conditions, filtered_counts, cqn_counts, md, model_variables, biomart_results) {
+wrap_de <- function(conditions, filtered_counts, cqn_counts, md,
+                    biomart_results, model_variables = NULL) {
   purrr::map(conditions,
-             function(x) differential_expression(filtered_counts, cqn_counts, md, model_variables,
-                                                 primary_variable = x, biomart_results))
+             function(x) differential_expression(filtered_counts, cqn_counts, md, primary_variable = x,
+                                                 biomart_results, model_variables))
 
 }
 #'

--- a/R/functions.R
+++ b/R/functions.R
@@ -506,12 +506,11 @@ build_formula <- function(md, primary_variable, model_variables = names(md)) {
 #' @inheritParams cqn
 #' @inheritParams coerce_factors
 #' @inheritParams build_formula
-#' @inheritDotParams build_formula
 #' @inheritParams cqn
 #' @export
 differential_expression <- function(filtered_counts, cqn_counts, md, primary_variable,
-                                    biomart_results, ...) {
-  metadata_input <- build_formula(md, model_variables, primary_variable)
+                                    biomart_results, model_variables = NULL) {
+  metadata_input <- build_formula(md, primary_variable, model_variables)
   gene_expression <- edgeR::DGEList(filtered_counts)
   gene_expression <- edgeR::calcNormFactors(gene_expression)
   voom_gene_expression <- variancePartition::voomWithDreamWeights(counts = gene_expression,

--- a/R/functions.R
+++ b/R/functions.R
@@ -461,9 +461,9 @@ build_formula <- function(md, model_variables = NULL, primary_variable) {
     md <- dplyr::select(md, dplyr::all_of(vars))
   }
   # Variables of factor or numeric class are required
-    col_type <- dplyr::select(md, -primary_variable) %>%
-      dplyr::summarise_all(class) %>%
-      tidyr::pivot_longer(tidyr::everything(), names_to = "variable", values_to = "class")
+  col_type <- dplyr::select(md, -primary_variable) %>%
+    dplyr::summarise_all(class) %>%
+    tidyr::pivot_longer(tidyr::everything(), names_to = "variable", values_to = "class")
 
   # Categorical or factor variables are modeled as a random effect by (1|variable)
   # Numeric variables are scaled to account for when the spread of data values differs

--- a/R/functions.R
+++ b/R/functions.R
@@ -450,7 +450,7 @@ mclust::mclustBIC
 #' fixed effect interaction term.
 #' @inheritParams coerce_factors
 #' @export
-build_formula <- function(md, model_variables = NULL, primary_variable) {
+build_formula <- function(md, primary_variable, model_variables = NULL) {
 
   if (!(all(purrr::map_lgl(md, function(x) inherits(x, c("numeric", "factor")))))) {
     stop("Use sageseqr::clean_covariates() to coerce variables into factor and numeric types.")
@@ -510,8 +510,8 @@ build_formula <- function(md, model_variables = NULL, primary_variable) {
 #' @inheritParams build_formula
 #' @inheritParams cqn
 #' @export
-differential_expression <- function(filtered_counts, cqn_counts, md, model_variables = NULL,
-                                    primary_variable, biomart_results) {
+differential_expression <- function(filtered_counts, cqn_counts, md, primary_variable,
+                                    biomart_results, model_variables = NULL) {
   metadata_input <- build_formula(md, model_variables, primary_variable)
   gene_expression <- edgeR::DGEList(filtered_counts)
   gene_expression <- edgeR::calcNormFactors(gene_expression)

--- a/R/functions.R
+++ b/R/functions.R
@@ -450,16 +450,14 @@ mclust::mclustBIC
 #' fixed effect interaction term.
 #' @inheritParams coerce_factors
 #' @export
-build_formula <- function(md, primary_variable, model_variables = NULL) {
+build_formula <- function(md, primary_variable, model_variables = names(md)) {
 
   if (!(all(purrr::map_lgl(md, function(x) inherits(x, c("numeric", "factor")))))) {
     stop("Use sageseqr::clean_covariates() to coerce variables into factor and numeric types.")
   }
   # Update metadata to reflect variable subset
-  if (!is.null(model_variables)) {
-    vars <- c(model_variables, primary_variable)
-    md <- dplyr::select(md, dplyr::all_of(vars))
-  }
+  md <- dplyr::select(md, dplyr::all_of(c(model_variables, primary_variable)))
+
   # Variables of factor or numeric class are required
   col_type <- dplyr::select(md, -primary_variable) %>%
     dplyr::summarise_all(class) %>%

--- a/man/build_formula.Rd
+++ b/man/build_formula.Rd
@@ -4,7 +4,7 @@
 \alias{build_formula}
 \title{Formula Builder}
 \usage{
-build_formula(md, primary_variable, model_variables = NULL)
+build_formula(md, primary_variable, model_variables = names(md))
 }
 \arguments{
 \item{md}{A data frame with sample identifiers in a column and relevant experimental covariates.}

--- a/man/build_formula.Rd
+++ b/man/build_formula.Rd
@@ -4,16 +4,16 @@
 \alias{build_formula}
 \title{Formula Builder}
 \usage{
-build_formula(md, model_variables = NULL, primary_variable)
+build_formula(md, primary_variable, model_variables = NULL)
 }
 \arguments{
 \item{md}{A data frame with sample identifiers in a column and relevant experimental covariates.}
 
-\item{model_variables}{Optional. Vector of variables to include in the linear (mixed) model.
-If not supplied, the model will include all variables in \code{md}.}
-
 \item{primary_variable}{Vector of variables that will be collapsed into a single
 fixed effect interaction term.}
+
+\item{model_variables}{Optional. Vector of variables to include in the linear (mixed) model.
+If not supplied, the model will include all variables in \code{md}.}
 }
 \description{
 If a linear mixed model is used, all categorical variables must be

--- a/man/build_formula.Rd
+++ b/man/build_formula.Rd
@@ -4,12 +4,13 @@
 \alias{build_formula}
 \title{Formula Builder}
 \usage{
-build_formula(md, model_variables, primary_variable)
+build_formula(md, model_variables = NULL, primary_variable)
 }
 \arguments{
 \item{md}{A data frame with sample identifiers in a column and relevant experimental covariates.}
 
-\item{model_variables}{Vector of variables to include in the linear (mixed) model.}
+\item{model_variables}{Optional. Vector of variables to include in the linear (mixed) model.
+If not supplied, the model will include all variables in \code{md}.}
 
 \item{primary_variable}{Vector of variables that will be collapsed into a single
 fixed effect interaction term.}

--- a/man/differential_expression.Rd
+++ b/man/differential_expression.Rd
@@ -8,7 +8,7 @@ differential_expression(
   filtered_counts,
   cqn_counts,
   md,
-  model_variables,
+  model_variables = NULL,
   primary_variable,
   biomart_results
 )
@@ -20,7 +20,8 @@ differential_expression(
 
 \item{md}{A data frame with sample identifiers in a column and relevant experimental covariates.}
 
-\item{model_variables}{Vector of variables to include in the linear (mixed) model.}
+\item{model_variables}{Optional. Vector of variables to include in the linear (mixed) model.
+If not supplied, the model will include all variables in \code{md}.}
 
 \item{primary_variable}{Vector of variables that will be collapsed into a single
 fixed effect interaction term.}

--- a/man/differential_expression.Rd
+++ b/man/differential_expression.Rd
@@ -8,9 +8,9 @@ differential_expression(
   filtered_counts,
   cqn_counts,
   md,
-  model_variables = NULL,
   primary_variable,
-  biomart_results
+  biomart_results,
+  model_variables = NULL
 )
 }
 \arguments{
@@ -20,13 +20,13 @@ differential_expression(
 
 \item{md}{A data frame with sample identifiers in a column and relevant experimental covariates.}
 
-\item{model_variables}{Optional. Vector of variables to include in the linear (mixed) model.
-If not supplied, the model will include all variables in \code{md}.}
-
 \item{primary_variable}{Vector of variables that will be collapsed into a single
 fixed effect interaction term.}
 
 \item{biomart_results}{Output of \code{"sageseqr::get_biomart()"}.}
+
+\item{model_variables}{Optional. Vector of variables to include in the linear (mixed) model.
+If not supplied, the model will include all variables in \code{md}.}
 }
 \description{
 Differential expression testing is performed with \code{"variancePartition::dream()"} to increase power

--- a/man/wrap_de.Rd
+++ b/man/wrap_de.Rd
@@ -9,8 +9,8 @@ wrap_de(
   filtered_counts,
   cqn_counts,
   md,
-  model_variables,
-  biomart_results
+  biomart_results,
+  model_variables = NULL
 )
 }
 \arguments{
@@ -23,10 +23,10 @@ in \code{"sagseqr::differential_expression()"}.}
 
 \item{md}{A data frame with sample identifiers in a column and relevant experimental covariates.}
 
+\item{biomart_results}{Output of \code{"sageseqr::get_biomart()"}.}
+
 \item{model_variables}{Optional. Vector of variables to include in the linear (mixed) model.
 If not supplied, the model will include all variables in \code{md}.}
-
-\item{biomart_results}{Output of \code{"sageseqr::get_biomart()"}.}
 }
 \description{
 This function will pass multiple conditions to test to \code{"sagseqr::differential_expression()"}.

--- a/man/wrap_de.Rd
+++ b/man/wrap_de.Rd
@@ -23,7 +23,8 @@ in \code{"sagseqr::differential_expression()"}.}
 
 \item{md}{A data frame with sample identifiers in a column and relevant experimental covariates.}
 
-\item{model_variables}{Vector of variables to include in the linear (mixed) model.}
+\item{model_variables}{Optional. Vector of variables to include in the linear (mixed) model.
+If not supplied, the model will include all variables in \code{md}.}
 
 \item{biomart_results}{Output of \code{"sageseqr::get_biomart()"}.}
 }

--- a/tests/testthat/test-de.R
+++ b/tests/testthat/test-de.R
@@ -26,9 +26,9 @@ biomart_results <- tibble::column_to_rownames(
 de <- differential_expression(counts,
                               counts,
                               md = metadata,
-                              model_variables = c("batch"),
                               primary_variable = c("sex", "diagnosis"),
-                              biomart_results = biomart_results)
+                              biomart_results = biomart_results,
+                              model_variables = c("batch"))
 
 test_that("output is a list of 6", {
   expect_equal(length(de), 6)

--- a/tests/testthat/test-wrap_de.R
+++ b/tests/testthat/test-wrap_de.R
@@ -34,8 +34,8 @@ all_de <- wrap_de(conditions,
                   counts,
                   counts,
                   metadata,
-                  model_variables = c("batch"),
-                  biomart_results)
+                  biomart_results,
+                  model_variables = c("batch"))
 
 test_that("conditions match differential expression output", {
   expect_equal(names(conditions), names(all_de))


### PR DESCRIPTION
`model_variables` is optional so that a user is able to provide a metadata data frame and all of the variables will be analyzed in the model. 

This will be the workflow in most cases. Passing `model_variables` explicitly is an edge case where a user may want to manually specify the steps of their stepwise regression.

My understanding is `function(argument = NULL)` is an acceptable way to specify optional arguments. I also see package developers pass `function(...)` for optional arguments. I opted to not use that approach since the optional argument would be completely obscured in the documentation. Curious to learn if there are alternatives to `NULL`.