### PR TITLE
make conditions an optional param for filter genes

### DIFF
--- a/man/filter_genes.Rd
+++ b/man/filter_genes.Rd
@@ -7,9 +7,9 @@
 filter_genes(
   clean_metadata,
   count_df,
-  conditions,
   cpm_threshold,
-  conditions_threshold
+  conditions_threshold,
+  conditions = NULL
 )
 }
 \arguments{
@@ -18,11 +18,12 @@ factors or numeric as determined by \code{"sageseqr::clean_covariates()"}.}
 
 \item{count_df}{A counts data frame with sample identifiers as column names.}
 
-\item{conditions}{Conditions to bin gene counts that correspond to variables in `md`.}
-
 \item{cpm_threshold}{The minimum number of CPM allowed.}
 
 \item{conditions_threshold}{Percentage of samples that should contain the minimum CPM.}
+
+\item{conditions}{Optional. Conditions to bin gene counts that correspond to
+variables in `md`.}
 }
 \description{
 Filter genes with low expression. This function is more permissive by setting conditions

--- a/man/rnaseq_plan.Rd
+++ b/man/rnaseq_plan.Rd
@@ -65,7 +65,8 @@ This specification is highly recommended for a reproducible workflow.
 \item{organism}{A character vector of the organism name. This argument
 takes partial strings. For example,"hsa" will match "hsapiens_gene_ensembl".}
 
-\item{conditions}{Conditions to bin gene counts that correspond to variables in `md`.}
+\item{conditions}{Optional. Conditions to bin gene counts that correspond to
+variables in `md`.}
 
 \item{cpm_threshold}{The minimum number of CPM allowed.}
 

--- a/tests/testthat/test-filter_genes.R
+++ b/tests/testthat/test-filter_genes.R
@@ -20,7 +20,7 @@ counts <- tibble::tribble(
 counts <- tibble::column_to_rownames(counts, var = "geneId")
 
 test_that("zero count genes are removed", {
-  filtered <- filter_genes(metadata, counts, conditions = "sex",
-                           cpm_threshold = 1, conditions_threshold = 0.5)
+  filtered <- filter_genes(metadata, counts, cpm_threshold = 1,
+                           conditions_threshold = 0.5, conditions = "sex")
   expect_equal(c("ENSG1", "ENSG2", "ENSG3", "ENSG5"), rownames(filtered))
 })


### PR DESCRIPTION
If the user does not want to specify a condition by which to constrain gene filtering, allow `conditions = NULL` for `filter_genes()`.