### PR TITLE
Improve repository documentation

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,46 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project lead or Sage Privacy Officer at <privacyofficer@sagebase.org>. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,19 @@
+# Contributing to sageseqr
+
+In the spirit of open and team science, contributions to this resource are encouraged and welcome!
+
+## File a bug 
+
+Document the problem in an issue that includes a [minimal reproducible example](https://www.tidyverse.org/help/#reprex).
+
+## Open a pull request (PR)
+
+* File an issue first to discuss the bug or idea proposed in the PR.
+* Create a Git branch for each pull request (PR).
+* The package uses [roxygen2](https://cran.r-project.org/package=roxygen2) and
+[Markdown syntax](https://roxygen2.r-lib.org/articles/rd-formatting.html) for function documentation.
+* Generally, new functions are tested with  [testthat](https://cran.r-project.org/package=testthat).
+
+## Code of Conduct
+
+sageseqr is released with a [Contributor Code of Conduct](CODE_OF_CONDUCT.md). By contributing to this project you agree to abide by its terms.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,6 +12,8 @@ Description: This workflow normalizes counts, performs model selection from know
     customizable threshold and performs differential expression analysis for repeated
     measures.
 License: MIT + file LICENSE
+URL: https://sage-bionetworks.github.io/sageseqr,
+    https://github.com/Sage-Bionetworks/sageseqr
 Encoding: UTF-8
 LazyData: true
 Suggests: 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,33 @@
 
 The `sageseqr` package integrates the [`drake` R package](https://github.com/ropensci/drake/), the [`config` package for R](https://cran.r-project.org/web/packages/config/vignettes/introduction.html), and [Synapse](https://www.synapse.org/). `drake` tracks dependency relationships in the workflow and only updates data when it has changed. A `config` file allows inputs and parameters to be explicitly defined in one location. Synapse is a data repository that allows sensitive data to be [stored and shared responsibly](https://docs.synapse.org/articles/article_index.html#governance). 
 
-The workflow takes RNA-seq gene counts and sample metadata as inputs, normalizes counts by [CQN](https://bioconductor.org/packages/release/bioc/html/cqn.html), removes outliers based on a user-defined threshold, empirically selects meaningful covariates and returns differential expression analysis results.
+The workflow takes RNA-seq gene counts and sample metadata as inputs, normalizes counts by conditional quantile normalization [(CQN)](https://bioconductor.org/packages/release/bioc/html/cqn.html), removes outliers based on a user-defined threshold, empirically selects meaningful covariates and returns differential expression analysis results. The data is also visualized in several ways to help you understand meaningful trends. The visualizations include a heatmap identifying highly correlated covariates, a sample-specific x and y marker gene check, boxplots visualizing the distribution of continuous variables and a principal component analysis (PCA) to visualize sample distribution.
+
+# The Targets
+
+The series of steps that make up the workflow are called targets. The target objects are stored in a cache and can either be read or loaded into your environment with the `drake` functions `readd` or `loadd`. Source code for each target can be visualized by setting `show_source = TRUE` with `loadd` and `readd`. The targets are called by the `sageseqr` `rnaseq_plan` function and are:
+
+Raw data: 
+- `import_metadata`
+- `import_counts`
+- `biomart_results` - the complete list of genes with biomaRt annotations.
+
+Exploratory data visualizations:
+- `gene_coexpression` - the distribution of correlated gene counts.
+- `boxplots` - the distribution of continuous variables.
+- `sex_plot` - the distribution of samples by x and y marker genes.
+- `correlation_plot` - the correlation of covariates.
+- `significant_covariates_plot` - the correlation of covariates to gene 
+                                  expression.
+- `outliers` - the clustering of samples by PCA.
+
+Transformed or normalized data:
+- `clean_md` - metadata with factor and numeric types.
+- `filtered_counts` - counts matrix with low gene expression removed.
+- `biotypes` - gene proportions summarized by biotype.
+- `cqn_counts` - CQN normalized counts. 
+- `model` - Model selected by multivariate forward stepwise regression 
+            (evaluated by Bayesian Information Criteria (BIC)).
 
 # Access to Data 
 

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ The workflow takes RNA-seq gene counts and sample metadata as inputs, normalizes
 The series of steps that make up the workflow are called targets. The target objects are stored in a cache and can either be read or loaded into your environment with the `drake` functions `readd` or `loadd`. Source code for each target can be visualized by setting `show_source = TRUE` with `loadd` and `readd`. The targets are called by the `sageseqr` `rnaseq_plan` function and are:
 
 Raw data: 
-- `import_metadata`
-- `import_counts`
+- `import_metadata`- imports the raw metadata directly from synapse
+- `import_counts` - imports the raw counts directly from synapse
 - `biomart_results` - the complete list of genes with biomaRt annotations.
 
 Exploratory data visualizations:

--- a/vignettes/customize-config.Rmd
+++ b/vignettes/customize-config.Rmd
@@ -14,22 +14,53 @@ knitr::opts_chunk$set(
 )
 ```
 
-A [configuration file](https://github.com/kelshmo/sageseqr/blob/master/config.yml) defines the inputs for the RNA-seq workflow. Update the default parameters to the Synapse ID where your data is stored and to the factor and continuous variables you want to test in the covariate model selection. The full list of configurable options are:
+A [configuration file](https://github.com/kelshmo/sageseqr/blob/master/config.yml) defines the inputs for the RNA-seq workflow. Update the default parameters to include the Synapse ID where your data is stored and to the factor and continuous variables you want to test in the covariate model selection. The full list of configurable options are:
 
 ```
+analysis title: The name of your project. This will become the name of your
+                cache and the name of your output html file.
 counts:
-  synID: Synapse ID to counts data frame with identifiers to the metadata as column names and gene ids in a column.
+  synID: Synapse ID to counts data frame with identifiers to the metadata as
+         column names and gene ids in a column.
   version: Optionally, include Synapse file version number (e.g. 3).
   gene id: Column name that corresponds to the gene ids (e.g. feature).
 metadata:
-  synID: Synapse ID to cleaned metadata file with sample identifiers in a column and variables of interest as column names.
+  synID: Synapse ID to cleaned metadata file with sample identifiers in a
+         column and variables of interest as column names.
   version: Optionally, include Synapse file version number (e.g. 3).
   sample id: Column name that corresponds to the sample ids (e.g. donorid).
 biomart:
-  synID: This input is optional. If left blank, Ensembl will be queried with the gene ids provided in the counts. Otherwise, you may provide the Synapse ID to gene metadata from Ensembl. This must include gene length and GC content in order to implement Conditional Quantile Normalization. 
+  synID: This input is optional. If left blank, Ensembl will be queried with
+         the gene ids provided in the counts. Otherwise, you may provide the
+         Synapse ID to gene metadata from Ensembl. This must include gene
+         length and GC content in order to implement Conditional Quantile
+         Normalization. 
   version: Optionally, include Synapse file version number (e.g. 3).
-  gene id: Column name that corresponds to the gene ids (e.g. ensembl_gene_id)
-factors: List of factor variables in brackets. Variables must be present in the metadata as column names (e.g. [ "donorid", "source"]).
-continuous: List of continuous variables in brackets. Variables must be present in the metadata as column names (e.g. [ "rin", "rin2"]).
-conditions: Filtering low-expression genes is a common practice to improve sensitivity in detection of differentially expressed genes. Low count genes that have less than 1 counts per million (cpm) in 50% of the samples per the conditions provided here will be removed. (e.g. ["diagnosis", "sex"])
+  filters: Column name that corresponds to the gene ids (e.g. ensembl_gene_id)
+  host: An optional character vector specifying the BioMart database release
+        version. This specification is highly recommended for a reproducible           workflow. Defaults to ensembl.org.
+  organism: A character vector of the organism name. This argument takes
+            partial strings. For example,"hsa" will match       
+            "hsapiens_gene_ensembl".
+factors: List of factor variables in brackets. Variables must be present in the
+         metadata as column names (e.g. [ "donorid", "source"]).
+continuous: List of continuous variables in brackets. Variables must be present
+            in the metadata as column names (e.g. [ "rin", "rin2"]).
+x_var: A boxplot will visualize the distribution of continuous variables using
+       the x_var as a dimension.
+conditions: Filtering low-expression genes is a common practice to improve
+            sensitivity in detection of differentially expressed genes. Low
+            count genes that have less than 1 counts per million (cpm) in 50%
+            of the samples per the conditions provided here will be removed.
+            (e.g. ["diagnosis", "sex"])
+sex check: The exact variable name that corresponds to reported gender or sex
+           to check the distribution of x and y marker expression across
+           samples.
+dimensions: Specify the PCA dimensions by variable name. 
+  color:
+  shape:
+  size:
+skip model: If TRUE, the exploratory data report is run. Model selection and 
+            differential expression is not computed.
+report: The output html report. 
 ```

--- a/vignettes/customize-config.Rmd
+++ b/vignettes/customize-config.Rmd
@@ -21,14 +21,14 @@ analysis title: The name of your project. This will become the name of your
                 cache and the name of your output html file.
 counts:
   synID: Synapse ID to counts data frame with identifiers to the metadata as
-         column names and gene ids in a column.
+         column names and gene ids in a column. (Required)
   version: Optionally, include Synapse file version number (e.g. 3).
-  gene id: Column name that corresponds to the gene ids (e.g. feature).
+  gene id: Column name that corresponds to the gene ids (e.g. feature). (Required)
 metadata:
   synID: Synapse ID to cleaned metadata file with sample identifiers in a
-         column and variables of interest as column names.
+         column and variables of interest as column names. (Required)
   version: Optionally, include Synapse file version number (e.g. 3).
-  sample id: Column name that corresponds to the sample ids (e.g. donorid).
+  sample id: Column name that corresponds to the sample ids (e.g. donorid). (Required)
 biomart:
   synID: This input is optional. If left blank, Ensembl will be queried with
          the gene ids provided in the counts. Otherwise, you may provide the


### PR DESCRIPTION
Fixes #69 and #67.

This PR brings the lagging documentation for configurable options up-to-speed. It also adds a contributing guide and code of conduct that will be surfaced on the `pkdgown` site homepage.

@jgockley62, would appreciate if you could check if the documentation is clear and easy to understand. 