### PR TITLE
Fix #106

### DIFF
--- a/R/visualization-functions.R
+++ b/R/visualization-functions.R
@@ -659,19 +659,40 @@ boxplot_vars <- function(md, include_vars, x_var) {
 plot_sexcheck <- function(clean_metadata, count_df, biomart_results, sex_var) {
   md <- tibble::rownames_to_column(clean_metadata, var = "sampleId") %>%
     dplyr::select(.data$sampleId, !!sex_var)
-  sex_specific <- count_df[grepl(paste0(rownames(biomart_results[biomart_results$hgnc_symbol %in% c("UTY", "XIST"),]), collapse = "|"), rownames(count_df)),]
+  sex_specific <- count_df[
+    grepl(
+      paste0(
+        rownames(
+          biomart_results[
+            biomart_results$hgnc_symbol %in% c("UTY", "XIST"),
+            ]),
+        collapse = "|"
+        ),
+      rownames(count_df)
+      ),
+    ]
   rownames(sex_specific) <- convert_geneids(sex_specific)
   sex_specific <- tibble::rownames_to_column(sex_specific, var = "geneId")
-  results <- dplyr::select(biomart_results, .data$hgnc_symbol, .data$chromosome_name)
+  results <- dplyr::select(
+    biomart_results,
+    .data$hgnc_symbol,
+    .data$chromosome_name
+    )
   results <- dplyr::filter(results, .data$hgnc_symbol %in% c("XIST", "UTY"))
   results <- tibble::rownames_to_column(results, var = "geneId")
   results <- dplyr::left_join(results, sex_specific)
-  results <- tidyr::pivot_longer(results,
-                                 -dplyr::all_of(c("geneId", "chromosome_name", "hgnc_symbol")),
-                                 names_to = "sampleId",
-                                 values_to = "counts(log)") %>%
-    dplyr::mutate(`counts(log)` = log(.data$`counts(log)`),
-                  `counts(log)` = ifelse(.data$`counts(log)` == -Inf, 0, .data$`counts(log)`))
+  results <- tidyr::pivot_longer(
+    results,
+    -dplyr::all_of(c("geneId", "chromosome_name", "hgnc_symbol")),
+    names_to = "sampleId",
+    values_to = "counts(log)"
+    ) %>%
+    dplyr::mutate(
+      `counts(log)` = log(.data$`counts(log)`),
+      `counts(log)` = ifelse(
+        .data$`counts(log)` == -Inf, 0, .data$`counts(log)`
+        )
+      )
   results <- tidyr::pivot_wider(
     dplyr::select(results, -chromosome_name, -geneId),
     names_from = "hgnc_symbol",

--- a/R/visualization-functions.R
+++ b/R/visualization-functions.R
@@ -672,10 +672,13 @@ plot_sexcheck <- function(clean_metadata, count_df, biomart_results, sex_var) {
                                  values_to = "counts(log)") %>%
     dplyr::mutate(`counts(log)` = log(.data$`counts(log)`),
                   `counts(log)` = ifelse(.data$`counts(log)` == -Inf, 0, .data$`counts(log)`))
+  results <- tidyr::pivot_wider(
+    dplyr::select(results, -chromosome_name, -geneId),
+    names_from = "hgnc_symbol",
+    values_from = "counts(log)"
+    )
   results <- dplyr::left_join(results, md, "sampleId")
-  results <- tidyr::spread(results, key = .data$hgnc_symbol, value = .data$`counts(log)`) %>%
-    dplyr::mutate(UTY = ifelse(is.na(.data$UTY), 0, .data$UTY),
-                  XIST = ifelse(is.na(.data$XIST), 0, .data$XIST))
+
   p <- ggplot2::ggplot(results, ggplot2::aes(x = .data$XIST, y = .data$UTY)) +
     ggplot2::geom_point(ggplot2::aes(color = .data[[sex_var]])) +
     sagethemes::scale_color_sage_d() +


### PR DESCRIPTION
Fixes #106. 

Uses `pivot_wider` to get XIST and UTY in two columns and one observation per row.