### PR TITLE
fix syntax based on issue drake #1135

### DIFF
--- a/R/functions.R
+++ b/R/functions.R
@@ -551,8 +551,13 @@ wrap_de <- function(conditions, filtered_counts, cqn_counts, md,
 #'
 #' @inheritParams differential_expression
 #' @inheritParams build_formula
+#' @param skip Defaults to NULL. If TRUE, this step will be skipped in the
+#' Drake plan.
 #' @export
-stepwise_regression <- function(md, model_variables = NULL, primary_variable, cqn_counts) {
+stepwise_regression <- function(md, model_variables = NULL,
+                                primary_variable, cqn_counts,
+                                skip = NULL) {
+  drake::cancel_if(isTRUE(skip))
   metadata_input <- build_formula(md, model_variables, primary_variable)
   model <- mvIC::mvForwardStepwise(exprObj = cqn_counts$E,
                                    baseFormula = metadata_input$formula,

--- a/R/plan.R
+++ b/R/plan.R
@@ -83,11 +83,11 @@ rnaseq_plan <- function(metadata_id, metadata_version, counts_id,
                                                                 clean_md),
     outliers = identify_outliers(filtered_counts, clean_md, !!color, !!shape,
                                  !!size),
-     model = drake::cancel_if(isTRUE(!!skip_model)),
-      stepwise_regression(
-        clean_md,
-        primary_variable = !!x_var_for_plot,
-        cqn_counts = cqn_counts
+     model = stepwise_regression(
+       clean_md,
+       primary_variable = !!x_var_for_plot,
+       cqn_counts = cqn_counts,
+       skip = !!skip_model
         ),
     report = rmarkdown::render(
       drake::knitr_in("sageseqr-report.Rmd"),

--- a/man/stepwise_regression.Rd
+++ b/man/stepwise_regression.Rd
@@ -4,7 +4,13 @@
 \alias{stepwise_regression}
 \title{Stepwise Regression}
 \usage{
-stepwise_regression(md, model_variables = NULL, primary_variable, cqn_counts)
+stepwise_regression(
+  md,
+  model_variables = NULL,
+  primary_variable,
+  cqn_counts,
+  skip = NULL
+)
 }
 \arguments{
 \item{md}{A data frame with sample identifiers in a column and relevant experimental covariates.}
@@ -16,6 +22,9 @@ If not supplied, the model will include all variables in \code{md}.}
 fixed effect interaction term.}
 
 \item{cqn_counts}{A counts data frame normalized by CQN.}
+
+\item{skip}{Defaults to NULL. If TRUE, this step will be skipped in the
+Drake plan.}
 }
 \description{
 This function performs multivariate forward stepwise regression evaluated by multivariate Bayesian Information


### PR DESCRIPTION
`drake::cancel_if` should be called within the function to keep `stepwise_regression` as a single target.e