### PR TITLE
Update dependencies

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -64,6 +64,6 @@ Remotes:
     th1vairam/CovariateAnalysis@dev,
     GabrielHoffman/mvIC@master,
     Sage-Bionetworks/sagethemes@main,
-    GabrielHoffman/variancePartition@da5003f
+    GabrielHoffman/variancePartition
 VignetteBuilder:
     knitr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -61,7 +61,6 @@ Imports:
 Additional_repositories:
     http://ran.synapse.org
 Remotes:
-    th1vairam/CovariateAnalysis@dev,
     GabrielHoffman/mvIC@master,
     Sage-Bionetworks/sagethemes@main,
     GabrielHoffman/variancePartition


### PR DESCRIPTION
- `mvIC` enforces a required `variancePartition` package version of 1.19.20.
- Remaining CovariateAnalysis code is now maintained in this package. 