### PR TITLE
Remove cache variable + add envir variable

### DIFF
--- a/R/functions.R
+++ b/R/functions.R
@@ -594,15 +594,13 @@ summarize_biotypes <- function(filtered_counts, biomart_results) {
 #'
 #' Store data in temporary files to prepare for Synapse upload.
 #' @param target The name of the object to be stored.
-#' @param path_to_cache Path to Drake cache.
 #' @param rowname Optional. If applicable, the name of the variable to store
 #' rownames.
 #' @export
-prepare_results <- function(target, path_to_cache, rowname = NULL) {
+prepare_results <- function(target, rowname = NULL) {
   df <- drake::readd(
     target,
-    character_only = TRUE,
-    cache = drake::drake_cache(path_to_cache)
+    character_only = TRUE
     )
   if (!is.null(rowname)) {
     df <- tibble::rownames_to_column(df, rowname)
@@ -636,7 +634,7 @@ prepare_results <- function(target, path_to_cache, rowname = NULL) {
 #' @inheritParams prepare_results
 #' @export
 store_results <- function(parent_id, targets, names, inputs,
-                          activity_provenance, path_to_cache, rownames = NULL,
+                          activity_provenance, rownames = NULL,
                           config_file = NULL, report_name = NULL) {
 
   # include sageseqr package version in Synapse provenance
@@ -647,7 +645,6 @@ store_results <- function(parent_id, targets, names, inputs,
 
   mash <- list(
     target = targets,
-    path_to_cache = path_to_cache,
     rowname = rownames
   )
 

--- a/R/plan.R
+++ b/R/plan.R
@@ -20,7 +20,7 @@
 #' @param biomart_id Synapse ID to biomart object.
 #' @param biomart_version Optionally, include Synapse file version number.
 #' @param x_var_for_plot Variable to separate groups for boxplot.
-#' @param report_name Name of output markdown file and cache.
+#' @param report_name Name of output markdown file.
 #' @inheritParams plot_sexcheck
 #' @inheritParams get_biomart
 #' @inheritParams filter_genes
@@ -37,7 +37,7 @@ rnaseq_plan <- function(metadata_id, metadata_version, counts_id,
                         conditions_threshold = 0.5,
                         x_var_for_plot, sex_var, color, shape, size,
                         report_name, skip_model, parent_id,
-                        rownames, config_file, path_to_cache) {
+                        rownames, config_file) {
   # Copies markdown to user's working directory
   if (!file.exists("sageseqr-report.Rmd")) {
     fs::file_copy(system.file("sageseqr-report.Rmd", package = "sageseqr"),
@@ -110,7 +110,6 @@ rnaseq_plan <- function(metadata_id, metadata_version, counts_id,
                    "Filtered counts (>1cpm)", "BioMart query results"),
       inputs = document_inputs,
       activity_provenance = "Analyze RNA-seq data with sageseqr pkg",
-      path_to_cache = !!path_to_cache,
       config_file = !!config_file,
       report_name = !!report_name
       )

--- a/inst/sageseqr-report.Rmd
+++ b/inst/sageseqr-report.Rmd
@@ -25,7 +25,7 @@ library(sageseqr)
 # Explore Metadata
 
 ```{r sample_summary, message = FALSE}
-drake::loadd(clean_md, cache = drake::drake_cache(project))
+drake::loadd(clean_md)
 var <- config::get("x_var")
 summary <- dplyr::group_by_at(clean_md, var)
 summary <- dplyr::summarise(summary, count = dplyr::n())
@@ -34,22 +34,21 @@ knitr::kable(summary)
 
 Visualize the distribution of data.
 ```{r boxplot}
-drake::readd(boxplots, cache = drake::drake_cache(project))
+drake::readd(boxplots)
 ```
 
 ```{r boxplot_sex_chromosomes, results = "asis"}
 if (!is.null(config::get("sex check"))) {
   cat("Visualize gene expression (log-transformed counts) of sex chromosomes using XIST 
       as a X-chromosome marker and UTY as a Y-chromosome marker.")
-  drake::readd(sex_plot, cache = drake::drake_cache(project))$plot
+  drake::readd(sex_plot)$plot
 }
 ```
 
 Visualize the relationships between covariates.
 ```{r heatmap_covariates}
 correlation_input <- drake::readd(
-  correlation_plot,
-  cache = drake::drake_cache(project)
+  correlation_plot
   )$plot
 col2 <- grDevices::colorRampPalette(rev(c("#67001F", "#B2182B", "#D6604D", "#F4A582",
                                  "#FDDBC7", "#FFFFFF", "#D1E5F0", "#92C5DE",
@@ -61,31 +60,30 @@ corrplot::corrplot(correlation_input, col = col2(200), tl.col = "#000000")
 
 Remove genes that have less than 1 counts per million (CPM) in at least 50% of samples per specified condition.
 
-`r dim(drake::readd(filtered_counts, cache = drake::drake_cache(project)))[1]` genes are used in this analysis.
+`r dim(drake::readd(filtered_counts))[1]` genes are used in this analysis.
 ```{r filter_genes}
-knitr::kable(drake::readd(biotypes, cache = drake::drake_cache(project)))
+knitr::kable(drake::readd(biotypes))
 ```
 
 Check distribution of correlation between genes.
 ```{r histogram}
-drake::readd(gene_coexpression, cache = drake::drake_cache(project))
+drake::readd(gene_coexpression)
 ```
 
 # Identify Outliers
 
 ```{r plot_outliers}
-drake::readd(outliers, cache = drake::drake_cache(project))$plot
+drake::readd(outliers)$plot
 ```
-Outliers, based on logCPM expression, are `r glue::glue_collapse(drake::readd(outliers, cache = drake::drake_cache(project)))$outliers, ", ", last = " and ")`.
+Outliers, based on logCPM expression, are `r glue::glue_collapse(drake::readd(outliers))$outliers, ", ", last = " and ")`.
 
 # Significant Covariates
 
-Significant covariates are identified by the pearson correlation (p-value of 1%) between principal component analysis (PCA) of normalized transcripts and variables that meet a 0.1 false discovery rate (FDR) threshold. Significant covariates to adjust for are `r glue::glue_collapse(drake::readd(significant_covariates_plot, cache = drake::drake_cache(project)))$significant_covariates, ", ", last = " and ")`.
+Significant covariates are identified by the pearson correlation (p-value of 1%) between principal component analysis (PCA) of normalized transcripts and variables that meet a 0.1 false discovery rate (FDR) threshold. Significant covariates to adjust for are `r glue::glue_collapse(drake::readd(significant_covariates_plot))$significant_covariates, ", ", last = " and ")`.
 
 ```{r pca_and_significant_covariates}
 drake::readd(
-  significant_covariates_plot,
-  cache = drake::drake_cache(project)
+  significant_covariates_plot
   )$plot
 ```
 
@@ -94,7 +92,7 @@ if (!isTRUE(config::get("skip model"))) {
   cat("# Model Identification
 Covariates are added as fixed and random effects iteratively if model improvement by  Bayesian Information Criteria (BIC) was observed.")
 
-summary <- drake::readd(model, cache = drake::drake_cache(project))
+summary <- drake::readd(model)
 knitr::kable(summary$to_visualize)
 as.character(summary$formula)[2]
 }

--- a/inst/sageseqr-report.Rmd
+++ b/inst/sageseqr-report.Rmd
@@ -79,7 +79,7 @@ Outliers, based on logCPM expression, are `r glue::glue_collapse(drake::readd(ou
 
 # Significant Covariates
 
-Significant covariates are identified by the pearson correlation (p-value of 1%) between principal component analysis (PCA) of normalized transcripts and variables that meet a 0.1 false discovery rate (FDR) threshold. Significant covariates to adjust for are `r glue::glue_collapse(drake::readd(significant_covariates_plot))$significant_covariates, ", ", last = " and ")`.
+Significant covariates are identified by the pearson correlation (p-value of 1%) between principal component analysis (PCA) of normalized transcripts and variables that meet a 0.1 false discovery rate (FDR) threshold. Significant covariates to adjust for are `r glue::glue_collapse(drake::readd(significant_covariates_plot)$significant_covariates, ", ", last = " and ")`.
 
 ```{r pca_and_significant_covariates}
 drake::readd(

--- a/inst/sageseqr-report.Rmd
+++ b/inst/sageseqr-report.Rmd
@@ -75,7 +75,7 @@ drake::readd(gene_coexpression)
 ```{r plot_outliers}
 drake::readd(outliers)$plot
 ```
-Outliers, based on logCPM expression, are `r glue::glue_collapse(drake::readd(outliers))$outliers, ", ", last = " and ")`.
+Outliers, based on logCPM expression, are `r glue::glue_collapse(drake::readd(outliers)$outliers, ", ", last = " and ")`.
 
 # Significant Covariates
 

--- a/man/prepare_results.Rd
+++ b/man/prepare_results.Rd
@@ -4,12 +4,10 @@
 \alias{prepare_results}
 \title{Prepare output}
 \usage{
-prepare_results(target, path_to_cache, rowname = NULL)
+prepare_results(target, rowname = NULL)
 }
 \arguments{
 \item{target}{The name of the object to be stored.}
-
-\item{path_to_cache}{Path to Drake cache.}
 
 \item{rowname}{Optional. If applicable, the name of the variable to store
 rownames.}

--- a/man/rnaseq_plan.Rd
+++ b/man/rnaseq_plan.Rd
@@ -30,8 +30,7 @@ rnaseq_plan(
   skip_model,
   parent_id,
   rownames,
-  config_file,
-  path_to_cache
+  config_file
 )
 }
 \arguments{
@@ -91,7 +90,7 @@ by shape.}
 \item{size}{Continuous variable in `clean_metadata` differentiated
 by size.}
 
-\item{report_name}{Name of output markdown file and cache.}
+\item{report_name}{Name of output markdown file.}
 
 \item{skip_model}{If TRUE, does not run regression model.}
 
@@ -102,8 +101,6 @@ folder to store output.}
 set as NULL.}
 
 \item{config_file}{Optional. Path to configuration file.}
-
-\item{path_to_cache}{Path to Drake cache.}
 }
 \description{
 This function wraps the \code{"drake::plan()"} and copies the R markdown

--- a/man/store_results.Rd
+++ b/man/store_results.Rd
@@ -10,7 +10,6 @@ store_results(
   names,
   inputs,
   activity_provenance,
-  path_to_cache,
   rownames = NULL,
   config_file = NULL,
   report_name = NULL
@@ -30,14 +29,12 @@ output files and input files.}
 \item{activity_provenance}{A phrase to describe the data transformation for
 provenance.}
 
-\item{path_to_cache}{Path to Drake cache.}
-
 \item{rownames}{A list of variables to store rownames. If not applicable,
 set as NULL.}
 
 \item{config_file}{Optional. Path to configuration file.}
 
-\item{report_name}{Name of output markdown file and cache.}
+\item{report_name}{Name of output markdown file.}
 }
 \description{
 Store transformed data, markdown and html report to a Folder in Synapse.

--- a/vignettes/customize-config.Rmd
+++ b/vignettes/customize-config.Rmd
@@ -17,8 +17,8 @@ knitr::opts_chunk$set(
 A [configuration file](https://github.com/kelshmo/sageseqr/blob/master/config.yml) defines the inputs for the RNA-seq workflow. Update the default parameters to include the Synapse ID where your data is stored and to the factor and continuous variables you want to test in the covariate model selection. The full list of configurable options are:
 
 ```
-analysis title: The name of your project. This will become the name of your
-                cache and the name of your output html file.
+analysis title: The name of your project. This will become the name of your 
+                output html file.
 counts:
   synID: Synapse ID to counts data frame with identifiers to the metadata as
          column names and gene ids in a column. (Required)

--- a/vignettes/run-the-plan.Rmd
+++ b/vignettes/run-the-plan.Rmd
@@ -23,7 +23,7 @@ knitr::opts_chunk$set(
 Sys.setenv(R_CONFIG_ACTIVE = "default")
 ```
 
-3. Load the `sageseqr` library and login to [Synapse](https://www.synapse.org/). `rnaseq_plan()` calls the arguments from the config file and creates the `drake` plan. Execute `drake::make(plan)` to compute. It is required to explicitly specify the name of the cache created with `drake::new_cache()` when multiple plans are executed in the same R session. Run this code from your project root.
+3. Load the `sageseqr` library and login to [Synapse](https://www.synapse.org/). `rnaseq_plan()` calls the arguments from the config file and creates the `drake` plan. Execute `drake::make(plan)` to compute. Run this code from your project root.
 
 ```{r run-plan}
 library(sageseqr)
@@ -61,16 +61,11 @@ plan <- sageseqr::rnaseq_plan(
     config::get("counts")$`gene id`,
     config::get("biomart results")$filters
     ),
-  config_file = "config.yml",
-  path_to_cache = config::get("analysis title")
+  config_file = "config.yml"
 )
 
 drake::make(
-  plan,
-  cache = drake::new_cache(
-    config::get(
-      "analysis title"
-      )
+  plan
     )
   )
 ```

--- a/vignettes/run-the-plan.Rmd
+++ b/vignettes/run-the-plan.Rmd
@@ -65,9 +65,9 @@ plan <- sageseqr::rnaseq_plan(
 )
 
 drake::make(
-  plan
+  plan,
+  envir = getNamespace("sageseqr")
     )
-  )
 ```
 
 4. Visualize the results of your work. 
@@ -75,6 +75,7 @@ drake::make(
 ```{r visualize}
 drake::vis_drake_graph(
   plan,
+  envir = getNamespace("sageseqr"),
   targets_only = TRUE
   )
 ```


### PR DESCRIPTION
The main use case of this package is not only RNA-seq processing, normalization and differential expression analysis, but meta-analysis across several cohorts with outputs to what is currently called the `rnaseq_plan`. `drake` creates a hidden cache to manage workflow steps and outputs. There is an option to pass a variable to name an "explicit" cache. I implemented this to allow the user to run plans in parallel, with different data, in the same R environment. In practice, this is extremely error prone, as switching between plans requires one to transition back and forth between the `R_CONFIG_ACTIVE`. Additionally, the `drake` visualization tool, that is very handy, was not functioning to properly visualize the outdated targets. All that to say - I, as the package author, was having trouble managing multiple data streams in parallel. So, I am removing this functionality and requiring plans to be executed in separate R environments. With containerization technologies (Docker), this is obviously the way best path forward. 

Thus, this PR: 
1. Removes the cache variable from all `readd`, `loadd` and `make` functions. 
2. Adds `envir = getNamespace("sageseqr")` to `make` and `vis_drake_graph`. In perusing the `drake` FAQs to solve this problem, I found issue 1286 that includes the `envir` variable so that the workflow checks whether functionality (function definitions etc.) in the package has changed and will re-execute the target if yes. 