### PR TITLE
model_variables defaults to all columns in md

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,8 @@ URL: https://sage-bionetworks.github.io/sageseqr,
 Encoding: UTF-8
 LazyData: true
 Suggests: 
-    testthat (>= 2.1.0)
+    testthat (>= 2.1.0),
+    markdown
 RoxygenNote: 7.1.1
 biocViews:
 Imports:

--- a/R/functions.R
+++ b/R/functions.R
@@ -563,7 +563,7 @@ differential_expression <- function(filtered_counts, cqn_counts, md, primary_var
 #' @inheritParams build_formula
 #' @export
 wrap_de <- function(conditions, filtered_counts, cqn_counts, md,
-                    biomart_results, model_variables = NULL) {
+                    biomart_results, model_variables = names(md)) {
   purrr::map(conditions,
              function(x) differential_expression(filtered_counts, cqn_counts, md, primary_variable = x,
                                                  biomart_results, model_variables))
@@ -579,8 +579,8 @@ wrap_de <- function(conditions, filtered_counts, cqn_counts, md,
 #' @param skip Defaults to NULL. If TRUE, this step will be skipped in the
 #' Drake plan.
 #' @export
-stepwise_regression <- function(md, model_variables = NULL,
-                                primary_variable, cqn_counts,
+stepwise_regression <- function(md, primary_variable, cqn_counts,
+                                model_variables = names(md),
                                 skip = NULL) {
   # skip stepwise generation if skip = TRUE
   if(isTRUE(skip)) {

--- a/R/functions.R
+++ b/R/functions.R
@@ -586,7 +586,7 @@ stepwise_regression <- function(md, primary_variable, cqn_counts,
   if(isTRUE(skip)) {
     return("Skipping stepwise regression model generation...")
   } else {
-  metadata_input <- build_formula(md, model_variables, primary_variable)
+  metadata_input <- build_formula(md, primary_variable, model_variables)
   model <- mvIC::mvForwardStepwise(exprObj = cqn_counts$E,
                                    baseFormula = metadata_input$formula,
                                    data = metadata_input$metadata,

--- a/R/functions.R
+++ b/R/functions.R
@@ -593,7 +593,7 @@ stepwise_regression <- function(md, primary_variable, cqn_counts,
                                    variables = array(metadata_input$variables)
   )
 
-  to_visualize <- model %>%
+  to_visualize <- model$trace %>%
     dplyr::select(.data$iter, .data$variable, .data$isAdded) %>%
     dplyr::rename(iteration = .data$iter,
                   `added to model` = .data$isAdded) %>%

--- a/R/functions.R
+++ b/R/functions.R
@@ -599,9 +599,12 @@ stepwise_regression <- function(md, primary_variable, cqn_counts,
                   `added to model` = .data$isAdded) %>%
     dplyr::filter(.data$`added to model` == "yes")
 
-  model["to_visualize"] <- to_visualize
+  output <- list(
+    to_visualize = to_visualize,
+    formula = model$formula
+  )
 
-  model
+  return(output)
   }
 }
 #' Summarize Biotypes

--- a/man/stepwise_regression.Rd
+++ b/man/stepwise_regression.Rd
@@ -6,22 +6,22 @@
 \usage{
 stepwise_regression(
   md,
-  model_variables = NULL,
   primary_variable,
   cqn_counts,
+  model_variables = names(md),
   skip = NULL
 )
 }
 \arguments{
 \item{md}{A data frame with sample identifiers in a column and relevant experimental covariates.}
 
-\item{model_variables}{Optional. Vector of variables to include in the linear (mixed) model.
-If not supplied, the model will include all variables in \code{md}.}
-
 \item{primary_variable}{Vector of variables that will be collapsed into a single
 fixed effect interaction term.}
 
 \item{cqn_counts}{A counts data frame normalized by CQN.}
+
+\item{model_variables}{Optional. Vector of variables to include in the linear (mixed) model.
+If not supplied, the model will include all variables in \code{md}.}
 
 \item{skip}{Defaults to NULL. If TRUE, this step will be skipped in the
 Drake plan.}

--- a/man/wrap_de.Rd
+++ b/man/wrap_de.Rd
@@ -10,7 +10,7 @@ wrap_de(
   cqn_counts,
   md,
   biomart_results,
-  model_variables = NULL
+  model_variables = names(md)
 )
 }
 \arguments{


### PR DESCRIPTION
Fixes #132. 

- `stepwise_regression` was passing `NULL` as a default value which caused the failure. The default should be all columns in `md`. 
- `build_formula()` was called from `stepwise_regression()` with incorrect argument ordering
- Updates output object to be a list with the formula and variables added to the model + iteration