### PR TITLE
argument order incorrect

### DIFF
--- a/vignettes/run-the-plan.Rmd
+++ b/vignettes/run-the-plan.Rmd
@@ -56,10 +56,10 @@ plan <- sageseqr::rnaseq_plan(
   skip_model = config::get("skip model"),
   parent_id = config::get("store output"),
   rownames = list(
-    config::get("counts")$`gene id`, 
     config::get("metadata")$`sample id`,
     config::get("counts")$`gene id`,
-    config::get("biomart results")$filters
+    config::get("biomart results")$filters,
+    config::get("counts")$`gene id`
     ),
   config_file = "config.yml"
 )

--- a/vignettes/run-the-plan.Rmd
+++ b/vignettes/run-the-plan.Rmd
@@ -58,7 +58,7 @@ plan <- sageseqr::rnaseq_plan(
   rownames = list(
     config::get("metadata")$`sample id`,
     config::get("counts")$`gene id`,
-    config::get("biomart results")$filters,
+    config::get("biomart")$filters,
     config::get("counts")$`gene id`
     ),
   config_file = "config.yml"


### PR DESCRIPTION
`store_results` requires  the argument `rownames` to be called in an order specific manner. The code in `run_the_plan` had two rownames reversed, but is corrected in this PR.