### PR TITLE
clarify what is required of rownames in these objects.

### DIFF
--- a/R/functions.R
+++ b/R/functions.R
@@ -135,7 +135,7 @@ parse_counts <- function(count_df){
 #'as rownames.
 #'
 #'@param count_df A counts data frame with sample identifiers as column names
-#'and transcript Ids removed with \code{"sageseqr::convert_geneids"}.
+#'and gene Ids are rownames.
 #'@inheritParams get_data
 #'@param filters A character vector listing biomaRt query filters.
 #'(For a list of filters see \code{"biomaRt::listFilters()"})
@@ -247,7 +247,8 @@ get_biomart <- function(count_df, synid, version, host, filters, organism) {
 #'Count normalization requires Ensembl Ids to be unique. In rare cases, there are more
 #'than one HGNC symbol per gene Id. This function collapses the duplicate entries into
 #'a single entry by appending the HGNC symbols in a comma separated list.
-#'@param biomart_results Output of \code{"sageseqr::get_biomart()"}.
+#'@param biomart_results Output of \code{"sageseqr::get_biomart()"}. Gene Ids are
+#'stored as rownames.
 #'@importFrom rlang .data
 #'
 #'@export

--- a/R/visualization-functions.R
+++ b/R/visualization-functions.R
@@ -851,7 +851,7 @@ identify_outliers <- function(filtered_counts, clean_metadata,
     )
 
   p <- p + sagethemes::scale_color_sage_d() +
-    sagethemes::theme_sage() +
+    sagethemes::scale_fill_sage_c() +
     ggplot2::theme(legend.position = "right") +
     ggplot2::geom_text(
       ggplot2::aes(label = .data$label),

--- a/R/visualization-functions.R
+++ b/R/visualization-functions.R
@@ -851,7 +851,7 @@ identify_outliers <- function(filtered_counts, clean_metadata,
     )
 
   p <- p + sagethemes::scale_color_sage_d() +
-    sagethemes::scale_fill_sage_c() +
+    sagethemes::theme_sage() +
     ggplot2::theme(legend.position = "right") +
     ggplot2::geom_text(
       ggplot2::aes(label = .data$label),

--- a/man/collapse_duplicate_hgnc_symbol.Rd
+++ b/man/collapse_duplicate_hgnc_symbol.Rd
@@ -7,7 +7,8 @@
 collapse_duplicate_hgnc_symbol(biomart_results)
 }
 \arguments{
-\item{biomart_results}{Output of \code{"sageseqr::get_biomart()"}.}
+\item{biomart_results}{Output of \code{"sageseqr::get_biomart()"}. Gene Ids are
+stored as rownames.}
 }
 \description{
 Count normalization requires Ensembl Ids to be unique. In rare cases, there are more

--- a/man/conditional_plot_sexcheck.Rd
+++ b/man/conditional_plot_sexcheck.Rd
@@ -11,9 +11,10 @@ conditional_plot_sexcheck(clean_metadata, count_df, biomart_results, sex_var)
 factors or numeric as determined by \code{"sageseqr::clean_covariates()"}.}
 
 \item{count_df}{A counts data frame with sample identifiers as column names
-and transcript Ids removed with \code{"sageseqr::convert_geneids"}.}
+and gene Ids are rownames.}
 
-\item{biomart_results}{Output of \code{"sageseqr::get_biomart()"}.}
+\item{biomart_results}{Output of \code{"sageseqr::get_biomart()"}. Gene Ids are
+stored as rownames.}
 
 \item{sex_var}{Column name of the sex or gender-specific metadata.}
 }

--- a/man/convert_geneids.Rd
+++ b/man/convert_geneids.Rd
@@ -8,7 +8,7 @@ convert_geneids(count_df)
 }
 \arguments{
 \item{count_df}{A counts data frame with sample identifiers as column names
-and transcript Ids removed with \code{"sageseqr::convert_geneids"}.}
+and gene Ids are rownames.}
 }
 \description{
 Get gene Ids

--- a/man/cqn.Rd
+++ b/man/cqn.Rd
@@ -9,7 +9,8 @@ cqn(filtered_counts, biomart_results)
 \arguments{
 \item{filtered_counts}{A counts data frame with genes removed that have low expression.}
 
-\item{biomart_results}{Output of \code{"sageseqr::get_biomart()"}.}
+\item{biomart_results}{Output of \code{"sageseqr::get_biomart()"}. Gene Ids are
+stored as rownames.}
 }
 \description{
 Normalize counts by CQN. By providing a biomart object, the systematic effect of GC content

--- a/man/differential_expression.Rd
+++ b/man/differential_expression.Rd
@@ -23,7 +23,8 @@ differential_expression(
 \item{primary_variable}{Vector of variables that will be collapsed into a single
 fixed effect interaction term.}
 
-\item{biomart_results}{Output of \code{"sageseqr::get_biomart()"}.}
+\item{biomart_results}{Output of \code{"sageseqr::get_biomart()"}. Gene Ids are
+stored as rownames.}
 
 \item{model_variables}{Optional. Vector of variables to include in the linear (mixed) model.
 If not supplied, the model will include all variables in \code{md}.}

--- a/man/filter_genes.Rd
+++ b/man/filter_genes.Rd
@@ -17,7 +17,7 @@ filter_genes(
 factors or numeric as determined by \code{"sageseqr::clean_covariates()"}.}
 
 \item{count_df}{A counts data frame with sample identifiers as column names
-and transcript Ids removed with \code{"sageseqr::convert_geneids"}.}
+and gene Ids are rownames.}
 
 \item{cpm_threshold}{The minimum number of CPM allowed.}
 

--- a/man/get_biomart.Rd
+++ b/man/get_biomart.Rd
@@ -8,7 +8,7 @@ get_biomart(count_df, synid, version, host, filters, organism)
 }
 \arguments{
 \item{count_df}{A counts data frame with sample identifiers as column names
-and transcript Ids removed with \code{"sageseqr::convert_geneids"}.}
+and gene Ids are rownames.}
 
 \item{synid}{A character vector with a Synapse Id.}
 

--- a/man/parse_counts.Rd
+++ b/man/parse_counts.Rd
@@ -8,7 +8,7 @@ parse_counts(count_df)
 }
 \arguments{
 \item{count_df}{A counts data frame with sample identifiers as column names
-and transcript Ids removed with \code{"sageseqr::convert_geneids"}.}
+and gene Ids are rownames.}
 }
 \description{
 The biomaRt query requires only gene identifiers to be passed as input. Some alignment

--- a/man/plot_sexcheck.Rd
+++ b/man/plot_sexcheck.Rd
@@ -11,9 +11,10 @@ plot_sexcheck(clean_metadata, count_df, biomart_results, sex_var)
 factors or numeric as determined by \code{"sageseqr::clean_covariates()"}.}
 
 \item{count_df}{A counts data frame with sample identifiers as column names
-and transcript Ids removed with \code{"sageseqr::convert_geneids"}.}
+and gene Ids are rownames.}
 
-\item{biomart_results}{Output of \code{"sageseqr::get_biomart()"}.}
+\item{biomart_results}{Output of \code{"sageseqr::get_biomart()"}. Gene Ids are
+stored as rownames.}
 
 \item{sex_var}{Column name of the sex or gender-specific metadata.}
 }

--- a/man/plot_sexcheck_pca.Rd
+++ b/man/plot_sexcheck_pca.Rd
@@ -11,9 +11,10 @@ plot_sexcheck_pca(clean_metadata, count_df, biomart_results, sex_var)
 factors or numeric as determined by \code{"sageseqr::clean_covariates()"}.}
 
 \item{count_df}{A counts data frame with sample identifiers as column names
-and transcript Ids removed with \code{"sageseqr::convert_geneids"}.}
+and gene Ids are rownames.}
 
-\item{biomart_results}{Output of \code{"sageseqr::get_biomart()"}.}
+\item{biomart_results}{Output of \code{"sageseqr::get_biomart()"}. Gene Ids are
+stored as rownames.}
 
 \item{sex_var}{Column name of the sex or gender-specific metadata.}
 }

--- a/man/simple_filter.Rd
+++ b/man/simple_filter.Rd
@@ -8,7 +8,7 @@ simple_filter(count_df, cpm_threshold, conditions_threshold)
 }
 \arguments{
 \item{count_df}{A counts data frame with sample identifiers as column names
-and transcript Ids removed with \code{"sageseqr::convert_geneids"}.}
+and gene Ids are rownames.}
 
 \item{cpm_threshold}{The minimum number of CPM allowed.}
 

--- a/man/summarize_biotypes.Rd
+++ b/man/summarize_biotypes.Rd
@@ -9,7 +9,8 @@ summarize_biotypes(filtered_counts, biomart_results)
 \arguments{
 \item{filtered_counts}{A counts data frame with genes removed that have low expression.}
 
-\item{biomart_results}{Output of \code{"sageseqr::get_biomart()"}.}
+\item{biomart_results}{Output of \code{"sageseqr::get_biomart()"}. Gene Ids are
+stored as rownames.}
 }
 \description{
 Computes the fraction of genes of a particular biotype. The number of genes

--- a/man/wrap_de.Rd
+++ b/man/wrap_de.Rd
@@ -23,7 +23,8 @@ in \code{"sagseqr::differential_expression()"}.}
 
 \item{md}{A data frame with sample identifiers in a column and relevant experimental covariates.}
 
-\item{biomart_results}{Output of \code{"sageseqr::get_biomart()"}.}
+\item{biomart_results}{Output of \code{"sageseqr::get_biomart()"}. Gene Ids are
+stored as rownames.}
 
 \item{model_variables}{Optional. Vector of variables to include in the linear (mixed) model.
 If not supplied, the model will include all variables in \code{md}.}


### PR DESCRIPTION
I confused myself reading the documentation for some of these functions when I was running them independently of the "plan". I think this clarifies object requirements.

This PR: 
- clarifies that `biomart_results` must have gene names as rownames 
- clarifies that `get_biomart` can accept any gene identifier (including those that include transcript Ids)