### PR TITLE
Fix model

### DIFF
--- a/R/functions.R
+++ b/R/functions.R
@@ -415,15 +415,27 @@ mclust::mclustBIC
 #' If not supplied, the model will include all variables in \code{md}.
 #' @param primary_variable Vector of variables that will be collapsed into a single
 #' fixed effect interaction term.
+#' @param exclude_variables Vector of variables to exclude from testing.
 #' @inheritParams coerce_factors
 #' @export
-build_formula <- function(md, primary_variable, model_variables = names(md)) {
-
+build_formula <- function(md, primary_variable, model_variables = NULL,
+                          exclude_variables = NULL) {
   if (!(all(purrr::map_lgl(md, function(x) inherits(x, c("numeric", "factor")))))) {
     stop("Use sageseqr::clean_covariates() to coerce variables into factor and numeric types.")
   }
+
+  if (!is.null(model_variables)) {
+    md <- dplyr::select(md, dplyr::all_of(c(model_variables, primary_variable)))
+  }
+
+  if (!is.null(exclude_variables)) {
+    if (exclude_variables %in% colnames(md)) {
+      stop("exclude_variables and model_variables are the same.")
+    }
+    md <- dplyr::select(md, -dplyr::all_of(exclude_variables))
+  }
+
   # Update metadata to reflect variable subset
-  md <- dplyr::select(md, dplyr::all_of(c(model_variables, primary_variable)))
 
   # Variables of factor or numeric class are required
   col_type <- dplyr::select(md, -primary_variable) %>%

--- a/R/functions.R
+++ b/R/functions.R
@@ -461,6 +461,9 @@ build_formula <- function(md, primary_variable, model_variables = names(md)) {
                              glue::glue_collapse(formula, sep = "+")
                              )
                   ),
+                formula_base_model = formula(
+                  glue::glue("~ {interaction_term}")
+                  ),
                 primary_variable = interaction_term,
                 variables = unlist(formula)
   )
@@ -589,7 +592,7 @@ stepwise_regression <- function(md, primary_variable, cqn_counts,
   } else {
   metadata_input <- build_formula(md, primary_variable, model_variables)
   model <- mvIC::mvForwardStepwise(exprObj = cqn_counts$E,
-                                   baseFormula = metadata_input$formula,
+                                   baseFormula = metadata_input$formula_base_model,
                                    data = metadata_input$metadata,
                                    variables = array(metadata_input$variables)
   )

--- a/R/functions.R
+++ b/R/functions.R
@@ -610,14 +610,17 @@ stepwise_regression <- function(md, primary_variable, cqn_counts,
   )
 
   to_visualize <- model$trace %>%
-    dplyr::select(.data$iter, .data$variable, .data$isAdded) %>%
+    dplyr::select(.data$iter, .data$variable, .data$delta,
+                  .data$score, .data$isAdded) %>%
     dplyr::rename(iteration = .data$iter,
-                  `added to model` = .data$isAdded) %>%
-    dplyr::filter(.data$`added to model` == "yes")
+                  `added to model` = .data$isAdded
+                  )
+  to_include <- model$trace$variable[model$trace$isAdded == "yes"]
 
   output <- list(
     to_visualize = to_visualize,
-    formula = model$formula
+    formula = model$formula,
+    variables_in_model = to_include
   )
 
   return(output)

--- a/R/functions.R
+++ b/R/functions.R
@@ -611,11 +611,11 @@ stepwise_regression <- function(md, primary_variable, cqn_counts,
 
   to_visualize <- model$trace %>%
     dplyr::select(.data$iter, .data$variable, .data$delta,
-                  .data$score, .data$isAdded, .data$m) %>%
+                  .data$score, .data$isBest, .data$isAdded, .data$m) %>%
     dplyr::rename(iteration = .data$iter,
                   `best (tested against baseline)` = .data$isBest,
                   `added to model` = .data$isAdded,
-                  `(effective) number of parameters estimated` = m
+                  `(effective) number of parameters estimated` = .data$m
                   )
   to_include <- model$trace$variable[model$trace$isAdded == "yes"]
 

--- a/R/functions.R
+++ b/R/functions.R
@@ -611,9 +611,11 @@ stepwise_regression <- function(md, primary_variable, cqn_counts,
 
   to_visualize <- model$trace %>%
     dplyr::select(.data$iter, .data$variable, .data$delta,
-                  .data$score, .data$isAdded) %>%
+                  .data$score, .data$isAdded, .data$m) %>%
     dplyr::rename(iteration = .data$iter,
-                  `added to model` = .data$isAdded
+                  `best (tested against baseline)` = .data$isBest,
+                  `added to model` = .data$isAdded,
+                  `(effective) number of parameters estimated` = m
                   )
   to_include <- model$trace$variable[model$trace$isAdded == "yes"]
 

--- a/R/plan.R
+++ b/R/plan.R
@@ -19,7 +19,8 @@
 #' present in the metadata as column names.
 #' @param biomart_id Synapse ID to biomart object.
 #' @param biomart_version Optionally, include Synapse file version number.
-#' @param x_var_for_plot Variable to separate groups for boxplot.
+#' @param primary_variable Baseline variable for model selection and variable to
+#'  stratify groups in the boxplot.
 #' @param report_name Name of output markdown file.
 #' @inheritParams plot_sexcheck
 #' @inheritParams get_biomart
@@ -35,7 +36,7 @@ rnaseq_plan <- function(metadata_id, metadata_version, counts_id,
                         biomart_id, biomart_version, host, filters,
                         organism, conditions, cpm_threshold = 1,
                         conditions_threshold = 0.5,
-                        x_var_for_plot, sex_var, color, shape, size,
+                        primary_variable, sex_var, color, shape, size,
                         report_name, skip_model, parent_id,
                         rownames, config_file) {
   # Copies markdown to user's working directory
@@ -72,7 +73,7 @@ rnaseq_plan <- function(metadata_id, metadata_version, counts_id,
     gene_coexpression = plot_coexpression(cqn_counts),
     boxplots = boxplot_vars(md = clean_md,
                             include_vars = !!continuous_input,
-                            x_var = !!x_var_for_plot),
+                            x_var = !!primary_variable),
     sex_plot = conditional_plot_sexcheck(clean_md,
                                          counts,
                                          biomart_results,
@@ -89,7 +90,7 @@ rnaseq_plan <- function(metadata_id, metadata_version, counts_id,
                                  !!size),
      model = stepwise_regression(
        clean_md,
-       primary_variable = !!x_var_for_plot,
+       primary_variable = !!primary_variable,
        cqn_counts = cqn_counts,
        skip = !!skip_model
         ),

--- a/man/build_formula.Rd
+++ b/man/build_formula.Rd
@@ -4,7 +4,12 @@
 \alias{build_formula}
 \title{Formula Builder}
 \usage{
-build_formula(md, primary_variable, model_variables = names(md))
+build_formula(
+  md,
+  primary_variable,
+  model_variables = NULL,
+  exclude_variables = NULL
+)
 }
 \arguments{
 \item{md}{A data frame with sample identifiers in a column and relevant experimental covariates.}
@@ -14,6 +19,8 @@ fixed effect interaction term.}
 
 \item{model_variables}{Optional. Vector of variables to include in the linear (mixed) model.
 If not supplied, the model will include all variables in \code{md}.}
+
+\item{exclude_variables}{Vector of variables to exclude from testing.}
 }
 \description{
 If a linear mixed model is used, all categorical variables must be

--- a/man/rnaseq_plan.Rd
+++ b/man/rnaseq_plan.Rd
@@ -21,7 +21,7 @@ rnaseq_plan(
   conditions,
   cpm_threshold = 1,
   conditions_threshold = 0.5,
-  x_var_for_plot,
+  primary_variable,
   sex_var,
   color,
   shape,
@@ -77,7 +77,8 @@ variables in `md`.}
 
 \item{conditions_threshold}{Percentage of samples that should contain the minimum CPM.}
 
-\item{x_var_for_plot}{Variable to separate groups for boxplot.}
+\item{primary_variable}{Baseline variable for model selection and variable to
+stratify groups in the boxplot.}
 
 \item{sex_var}{Column name of the sex or gender-specific metadata.}
 

--- a/tests/testthat/test-build_formula.R
+++ b/tests/testthat/test-build_formula.R
@@ -10,13 +10,24 @@ metadata <- data.frame(
 output <- build_formula(
   metadata,
   primary_variable = "diagnosis",
-  model_variables = c("batch")
+  model_variables = "batch"
 )
 
 test_that("output data frame subset to primary and model variables.", {
-  expect_equal(colnames(output$metadata), c("diagnosis", "batch"))
+  expect_vector(colnames(output$metadata), c("diagnosis", "batch"))
 })
 
 test_that("output is formula.",{
   expect_equal(class(output$formula), "formula")
+})
+
+test_that("error if variables are both included and excluded",{
+  expect_error(
+    build_formula(
+      metadata,
+      primary_variable = "diagnosis",
+      model_variables = "batch",
+      exclude_variables = "batch"
+      )
+    )
 })

--- a/tests/testthat/test-build_formula.R
+++ b/tests/testthat/test-build_formula.R
@@ -1,0 +1,22 @@
+metadata <- data.frame(
+  batch = rep( c("1", "2", "1", "2", "1", "2", "1", "2"), 2),
+  diagnosis = rep( c("dx", "dx", "ct", "ct", "dx", "dx", "ct", "ct"), 2),
+  sex = rep( c("M", "F", "M", "F", "M", "F", "M", "F"), 2),
+  RIN = rep( c(5, 5, 5, 5, 5, 5, 5, 5), 2),
+  row.names = c( paste0("S", c(1:16))),
+  stringsAsFactors = TRUE
+)
+
+output <- build_formula(
+  metadata,
+  primary_variable = "diagnosis",
+  model_variables = c("batch")
+)
+
+test_that("output data frame subset to primary and model variables.", {
+  expect_equal(colnames(output$metadata), c("diagnosis", "batch"))
+})
+
+test_that("output is formula.",{
+  expect_equal(class(output$formula), "formula")
+})


### PR DESCRIPTION
`stepwise_regression` requires the specification of a `baseFormula` and the variables to test as `variables`. This fix provides this information in two separate vectors instead of in one formula.

This PR also adds an optional argument to `build_formula` to accept variables to exclude instead of variables to include. This will be helpful in scaling conditions for differential_expression.

I also output more information from the regression trace: The complete list of iterations, delta and score.