### PR TITLE
test pat increasing rate limit

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -5,6 +5,8 @@ name: R-CMD-check
 jobs:
   R-CMD-check:
     runs-on: macOS-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v1
       - uses: r-lib/actions/setup-r@master


### PR DESCRIPTION
Rate limiting is potentially causing tests to fail. This PR adds an environmental variable `GITHUB_TOKEN` and secrets are set.