### PR TITLE
force first line to be header

### DIFF
--- a/R/functions.R
+++ b/R/functions.R
@@ -14,9 +14,15 @@
 #'
 #'}
 get_data <- function(synid, version = NULL) {
-  df <- tibble::as_tibble(data.table::fread(synapser::synGet(synid,
-                                                     version = as.numeric(version)
-                                                     )$path))
+  df <- tibble::as_tibble(
+    data.table::fread(
+      synapser::synGet(
+        synid,
+        version = as.numeric(version)
+        )$path,
+      header = TRUE
+      )
+    )
   df
 }
 #' Create complete URL to Synapse entity


### PR DESCRIPTION
`fread` in `sageseqr::get_data()` will fail if sample identifiers are numeric as `fread` looks for  "whether every non-empty field on the first data line is type character." This fix forces a header.