### PR TITLE
Issue #24 - Test for Unique EnsemblIDs in Config biomaRt

### DIFF
--- a/R/functions.R
+++ b/R/functions.R
@@ -232,7 +232,7 @@ get_biomart <- function(count_df, synid, version, host, filters, organism) {
     if (nrow(gene_ids_uploaded) != (nrow(unique(gene_ids_uploaded)))){
       warning("Duplicate Ensembl IDs were found in your uploaded biomaRt file.
               Duplicates have been collapsed into a single entry.")
-      biomart_results <- biomart_results %>% dplyr::group_by(var = filters) %>% unique()
+      biomart_results <- biomart_results %>% dplyr::group_by(.dots = filters) %>% unique()
     }
 
     # Biomart IDs as rownames

--- a/R/functions.R
+++ b/R/functions.R
@@ -227,6 +227,14 @@ get_biomart <- function(count_df, synid, version, host, filters, organism) {
     # Download biomart object from syndID specified in config.yml
     biomart_results <- get_data(synid, version)
 
+    # Check if Ensembl Ids are unique. If not, collapse into single entry
+    gene_ids_uploaded <- biomart_results %>% dplyr::select(var = filters)
+    if (nrow(gene_ids_uploaded) != (nrow(unique(gene_ids_uploaded)))){
+      warning("Duplicate Ensembl IDs were found in your uploaded biomaRt file.
+              Duplicates have been collapsed into a single entry.")
+      biomart_results <- biomart_results %>% dplyr::group_by(var = filters) %>% unique()
+    }
+
     # Biomart IDs as rownames
     biomart_results <- tibble::column_to_rownames(
       biomart_results, var = filters


### PR DESCRIPTION
I think `get_biomart` fails before `cqn` if the Ensembl IDs aren't unique (per #24) because [the Ensembl IDs are set as row names](https://github.com/Sage-Bionetworks/sageseqr/blob/d0a5a6412b46f1f2f2ae3d409514898f52e4f869/R/functions.R#L230).

So I added a warning message and collapsed the duplicates in the uploaded biomaRt, but can error instead if that's preferred, @kelshmo?