### PR TITLE
Make biomart query permissive to more organisms

### DIFF
--- a/R/functions.R
+++ b/R/functions.R
@@ -260,6 +260,20 @@ get_biomart <- function(count_df, synid, version, host, filters, organism) {
       biomart_results, var = filters
       )
 
+    # Biomart query can add NAs as charactesr and empty strings. Convert those
+    # to NA values
+    biomart_results <- dplyr::mutate_all(
+      biomart_results,
+      na_if,
+      ""
+    )
+
+    biomart_results <- dplyr::mutate_all(
+      biomart_results,
+      na_if,
+      "NA"
+    )
+
     # Gene metadata required for count CQN
     required_variables <- c("gene_length", "percentage_gene_gc_content")
 

--- a/R/functions.R
+++ b/R/functions.R
@@ -230,6 +230,20 @@ get_biomart <- function(count_df, synid, version, host, filters, organism) {
     # Duplicate Ensembl Ids are collapsed into a single entry
     biomart_results <- collapse_duplicate_hgnc_symbol(biomart_results)
 
+    # Biomart query can add NAs as charactesr and empty strings. Convert those
+    # to NA values
+    biomart_results <- dplyr::mutate_all(
+      biomart_results,
+      na_if,
+      ""
+    )
+
+    biomart_results <- dplyr::mutate_all(
+      biomart_results,
+      na_if,
+      "NA"
+    )
+
     # Biomart IDs as rownames
     biomart_results <- tibble::column_to_rownames(
       biomart_results, var = filters

--- a/R/functions.R
+++ b/R/functions.R
@@ -145,6 +145,7 @@ parse_counts <- function(count_df){
 #'
 #'@param count_df A counts data frame with sample identifiers as column names
 #'and gene Ids are rownames.
+#'@param synid Optional. A character vector with a Synapse Id.
 #'@inheritParams get_data
 #'@param filters A character vector listing biomaRt query filters.
 #'(For a list of filters see \code{"biomaRt::listFilters()"})

--- a/man/biomart_obj.Rd
+++ b/man/biomart_obj.Rd
@@ -7,7 +7,10 @@
 biomart_obj(organism, host)
 }
 \arguments{
-\item{organism}{A character vector of the organism name. This argument takes partial strings. For example,"hsa" will match "hsapiens_gene_ensembl".}
+\item{organism}{A character vector of the organism name. The organisms
+scientific name is required to query biomaRt. This argument accepts partial
+strings. For example,"hsa" will match "hsapiens_gene_ensembl" or "mmus" will
+match ""mmusculus_gene_ensembl".}
 
 \item{host}{An optional character vector specifying the release version. This specification is highly recommended for a reproducible workflow. (see \code{"biomaRt::listEnsemblArchives()"})}
 }

--- a/man/get_biomart.Rd
+++ b/man/get_biomart.Rd
@@ -10,7 +10,7 @@ get_biomart(count_df, synid, version, host, filters, organism)
 \item{count_df}{A counts data frame with sample identifiers as column names
 and gene Ids are rownames.}
 
-\item{synid}{A character vector with a Synapse Id.}
+\item{synid}{Optional. A character vector with a Synapse Id.}
 
 \item{version}{Optional. A numeric vector with the Synapse file
 version number.}
@@ -22,8 +22,10 @@ This specification is highly recommended for a reproducible workflow.
 \item{filters}{A character vector listing biomaRt query filters.
 (For a list of filters see \code{"biomaRt::listFilters()"})}
 
-\item{organism}{A character vector of the organism name. This argument
-takes partial strings. For example,"hsa" will match "hsapiens_gene_ensembl".}
+\item{organism}{A character vector of the organism name. The organisms
+scientific name is required to query biomaRt. This argument accepts partial
+strings. For example,"hsa" will match "hsapiens_gene_ensembl" or "mmus" will
+match ""mmusculus_gene_ensembl".}
 }
 \description{
 Get GC content, gene Ids, gene symbols, gene biotypes, gene lengths

--- a/man/rnaseq_plan.Rd
+++ b/man/rnaseq_plan.Rd
@@ -72,8 +72,10 @@ This specification is highly recommended for a reproducible workflow.
 \item{filters}{A character vector listing biomaRt query filters.
 (For a list of filters see \code{"biomaRt::listFilters()"})}
 
-\item{organism}{A character vector of the organism name. This argument
-takes partial strings. For example,"hsa" will match "hsapiens_gene_ensembl".}
+\item{organism}{A character vector of the organism name. The organisms
+scientific name is required to query biomaRt. This argument accepts partial
+strings. For example,"hsa" will match "hsapiens_gene_ensembl" or "mmus" will
+match ""mmusculus_gene_ensembl".}
 
 \item{conditions}{Optional. Conditions to bin gene counts that correspond to
 variables in `md`.}


### PR DESCRIPTION
Fixes #167. 

- hgnc_symbol was hard coded all over the place. For non-human organisms, the gene symbol column name may differ (e.g. mgi_symbol for mouse). This code adds `grep` to search for columns with "symbol".
- When querying for _mus musculus_, I noticed there was a mix of empty strings "" and NA characters. I added some cleaning to convert these values to proper NA. This is necessary for some downstream code to function properly.